### PR TITLE
whitelisted blacklisted actions

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -3,14 +3,7 @@ var AWS = require('aws-sdk');
 module.exports = function(message, callback) {
 
   if (process.env.NODE_ENV == 'test') {
-    AWS.SNS = function() {};
-
-    AWS.SNS.prototype.publish = function(params, callback) {
-      callback(null, {
-        MessageId: '1234'
-      });
-      return new events.EventEmitter();
-    };
+    callback(null, message);
   } else {
     var sns = new AWS.SNS();
     var params = {

--- a/test/rules/assumeRole.test.js
+++ b/test/rules/assumeRole.test.js
@@ -46,8 +46,10 @@ test('assumeRole rule', function(t) {
 
   fn(event, function(err, message) {
     t.error(err, 'No error when calling ' + name);
-    t.equal(message, 'Blacklisted role Administrator assumed by bob',
-      'Matches blacklisted Administrator role');
+    t.deepEqual(message, {
+      body: 'Blacklisted role Administrator assumed by bob',
+      subject: 'Blacklisted role Administrator assumed'
+    }, 'Matches blacklisted Administrator role');
   });
 
   var event = {

--- a/test/rules/whitelisted_iam_actions.test.js
+++ b/test/rules/whitelisted_iam_actions.test.js
@@ -1,0 +1,103 @@
+var test = require('tape');
+
+var rule = require('../../rules/whitelisted_iam_actions.js');
+var fn = rule.fn;
+var name = rule.config.name;
+
+test('whitelisted_iam_actions rule', function(t) {
+
+  var event = {
+    "detail": {
+      "userIdentity": {
+        "userName": "bob",
+      },
+      "requestParameters": {
+        "roleArn": "arn:aws:iam::12345678901:role/Administrator-123456",
+        "roleSessionName": "bob"
+      }
+    }
+  };
+
+  var docMixed = {
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: [
+          "cloudtrail:*"
+        ]
+      },
+      {
+        Effect: "Allow",
+        Action: [
+          "iam:*"
+        ]
+      },
+      {
+        Effect: "Allow",
+        Action: [
+          "ec2:*"
+        ]
+      },
+      {
+        Effect: "Allow",
+        Action: [
+          "iam:PutUserPolicy"
+        ]
+      },
+    ]
+  };
+
+  event.detail.requestParameters.policyDocument = JSON.stringify(docMixed);
+
+  process.env.whitelistedActions = 'iam:PassRole';
+  process.env.blacklistedServices = 'iam, cloudtrail';
+
+  fn(event, function(err, message) {
+    t.equal(message.subject, 'Blacklisted actions cloudtrail:* iam:* ec2:* iam:PutUserPolicy used in policy',
+      'Alarms on multiple blacklist matches');
+  });
+
+  var docWhitelistedBlacklisted = {
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: [
+          "iam:PassRole"
+        ]
+      },
+      {
+        Effect: "Allow",
+        Action: [
+          "iam:PutUserPolicy"
+        ]
+      },
+    ]
+  };
+
+  event.detail.requestParameters.policyDocument = JSON.stringify(docWhitelistedBlacklisted);
+
+  fn(event, function(err, message) {
+    t.equal(message.subject, 'Blacklisted actions iam:PutUserPolicy used in policy',
+      'Alarms on multiple blacklist matches');
+  });
+
+  var docWhitelisted = {
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: [
+          "iam:PassRole"
+        ]
+      }
+    ]
+  };
+
+  event.detail.requestParameters.policyDocument = JSON.stringify(docWhitelisted);
+
+  fn(event, function(err, message) {
+    t.equal(undefined, undefined, 'No alarm on whitelisted action');
+  });
+
+  t.end();
+
+});


### PR DESCRIPTION
Fixes #14 
- Specify blacklisted services
- Allow poking holes for certain actions on those services
- Never allow `*` as the API call, like `foo:*`
