### PR TITLE
Fixes blacklist test and modularize splitOnComma

### DIFF
--- a/rules/blacklisted_resources.js
+++ b/rules/blacklisted_resources.js
@@ -1,6 +1,7 @@
 var AWS = require('aws-sdk');
 var queue = require('queue-async');
 var message = require('../lib/message');
+var utils = require('../lib/utils');
 
 module.exports.config = {
   name: 'blacklistedResources',
@@ -16,7 +17,8 @@ module.exports.fn = function(event, callback) {
 
   var iam = new AWS.IAM();
   var q = queue(1);
-  var blacklisted = module.exports.splitOnComma(process.env.blacklistedResourceArns);
+
+  var blacklisted = utils.splitOnComma(process.env.blacklistedResourceArns);
   var document = event.detail.requestParameters.policyDocument;
   var parsed = JSON.parse(document);
 
@@ -84,8 +86,4 @@ module.exports.fn = function(event, callback) {
     });
   });
 
-};
-
-module.exports.splitOnComma = function(str) {
-  return str.split(/\s*,\s*/);
 };

--- a/test/rules/blacklisted_resources.test.js
+++ b/test/rules/blacklisted_resources.test.js
@@ -6,6 +6,8 @@ var name = rule.config.name;
 
 test('blacklisted_resources rule', function(t) {
 
+  process.env.blacklistedResourceArns = 'arn:aws:s3:::foo/bar/baz, arn:aws:s3:::foo/bar';
+
   var event = {
     "detail": {
       "userIdentity": {
@@ -30,9 +32,9 @@ test('blacklisted_resources rule', function(t) {
   };
 
   event.detail.requestParameters.policyDocument = JSON.stringify(docNoMatch);
-  process.env.blacklistedResources = 'arn:aws:s3:::foo/bar/baz, arn:aws:s3:::foo/bar';
 
   fn(event, function(err, message) {
+    t.error(err, 'No error when calling ' + name);
     t.deepEqual(message, [], 'No matched blacklisted resources');
   });
 
@@ -51,7 +53,6 @@ test('blacklisted_resources rule', function(t) {
   };
 
   event.detail.requestParameters.policyDocument = JSON.stringify(docMatch);
-  process.env.blacklistedResources = 'arn:aws:s3:::foo/bar/baz, arn:aws:s3:::foo/bar';
 
   fn(event, function(err, message) {
     t.equal(message.length, 1, 'There is only one result');
@@ -81,7 +82,6 @@ test('blacklisted_resources rule', function(t) {
   };
 
   event.detail.requestParameters.policyDocument = JSON.stringify(docMixed);
-  process.env.blacklistedResources = 'arn:aws:s3:::foo/bar/baz, arn:aws:s3:::foo/bar';
 
   fn(event, function(err, message) {
     t.equal(message.length, 1, 'There is only one result');
@@ -111,7 +111,6 @@ test('blacklisted_resources rule', function(t) {
   };
 
   event.detail.requestParameters.policyDocument = JSON.stringify(docFuzzyMatch);
-  process.env.blacklistedResources = 'arn:aws:s3:::foo/bar/baz, arn:aws:s3:::foo/bar';
 
   fn(event, function(err, message) {
     t.equal(message.length, 1, 'There is only one result');
@@ -141,7 +140,7 @@ test('blacklisted_resources rule', function(t) {
   };
 
   event.detail.requestParameters.policyDocument = JSON.stringify(docKinesisMatch);
-  process.env.blacklistedResources = 'arn:aws:kinesis:us-east-1:123456789012:stream/foo-bar-KinesisStream-ABC*, arn:aws:s3:::foo/bar';
+  process.env.blacklistedResourceArns = 'arn:aws:kinesis:us-east-1:123456789012:stream/foo-bar-KinesisStream-ABC*, arn:aws:s3:::foo/bar';
 
   fn(event, function(err, message) {
     t.equal(message.length, 1, 'There is only one result');
@@ -180,7 +179,7 @@ test('blacklisted_resources rule', function(t) {
   };
 
   event.detail.requestParameters.policyDocument = JSON.stringify(docTwoMatches);
-  process.env.blacklistedResources = 'arn:aws:kinesis:us-east-1:123456789012:stream/foo-bar-KinesisStream-ABC*, arn:aws:s3:::foo/bar';
+  process.env.blacklistedResourceArns = 'arn:aws:kinesis:us-east-1:123456789012:stream/foo-bar-KinesisStream-ABC*, arn:aws:s3:::foo/bar';
 
   fn(event, function(err, message) {
     t.equal(message.length, 1, 'There is only one result');


### PR DESCRIPTION
Fixes issue with variable names in `blacklisted_resources.test.js`

Removes splitOnComma function from `blacklisted_resources.js` and gets from `utils.js` instead

/cc @ianshward 
