### PR TITLE
Fixes bug with CloudTrail event JSON

### DIFF
--- a/rules/cloudTrail.js
+++ b/rules/cloudTrail.js
@@ -27,7 +27,7 @@ module.exports.fn = function(event, callback) {
 
   var blacklisted = utils.splitOnComma(process.env.blacklistedEvents);
   var couldTrailEvent = event.detail.eventName;
-  var cloudTrailARN = event.requestParameters.name;
+  var cloudTrailARN = event.detail.requestParameters.name;
 
   // Check for fuzzy match
   var match = blacklisted.filter(function(event) {

--- a/test/rules/cloudTrail.test.js
+++ b/test/rules/cloudTrail.test.js
@@ -14,10 +14,10 @@ test('cloudTrail rule', function(t) {
   var newTrailEvent = {
     "detail": {
       "eventSource": "cloudtrail.amazonaws.com",
-      "eventName": "UndocumentedEvent"
-    },
-    "requestParameters": {
-      "name": 'arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail'
+      "eventName": "UndocumentedEvent",
+      "requestParameters": {
+        "name": 'arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail'
+      }
     }
   };
 
@@ -42,10 +42,10 @@ function createTest(eventName, t) {
   var event = {
     "detail": {
       "eventSource": "cloudtrail.amazonaws.com",
-      "eventName": eventName
-    },
-    "requestParameters": {
-      "name": 'arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail'
+      "eventName": eventName,
+      "requestParameters": {
+        "name": 'arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail'
+      }
     }
   };
 


### PR DESCRIPTION
Fixes bug with CloudTrail event JSON that caused Lambda invocation errors

Changes event.requestParameters.name to event.detail.requestParameters.name
in both cloudTrail.js and cloudTrail.test.js

/cc @ianshward 
