### PR TITLE
CloudTrail rule fixes

### DIFF
--- a/rules/cloudTrail.js
+++ b/rules/cloudTrail.js
@@ -34,7 +34,7 @@ module.exports.fn = function(event, callback) {
 
   var blacklisted = utils.splitOnComma(process.env.blacklistedEvents);
   var couldTrailEvent = event.detail.eventName;
-  var cloudTrailARN = event.detail.requestParameters.name;
+  //var cloudTrailARN = event.detail.requestParameters.name;
 
   // Check for fuzzy match
   var match = blacklisted.filter(function(event) {
@@ -43,8 +43,8 @@ module.exports.fn = function(event, callback) {
 
   if (match.length > 0) {
     var notif = {
-      subject: couldTrailEvent + ' called on ' + cloudTrailARN,
-      body: couldTrailEvent + ' called on ' + cloudTrailARN
+      subject: couldTrailEvent + ' - CloudTrail',
+      body: couldTrailEvent + ' - CloudTrail'
     };
     message(notif, function(err, result) {
       callback(err, result);

--- a/test/rules/cloudTrail.test.js
+++ b/test/rules/cloudTrail.test.js
@@ -14,10 +14,7 @@ test('cloudTrail rule', function(t) {
   var newTrailEvent = {
     "detail": {
       "eventSource": "cloudtrail.amazonaws.com",
-      "eventName": "UndocumentedEvent",
-      "requestParameters": {
-        "name": 'arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail'
-      }
+      "eventName": "UndocumentedEvent"
     }
   };
 
@@ -42,17 +39,14 @@ function createTest(eventName, t) {
   var event = {
     "detail": {
       "eventSource": "cloudtrail.amazonaws.com",
-      "eventName": eventName,
-      "requestParameters": {
-        "name": 'arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail'
-      }
+      "eventName": eventName
     }
   };
 
   fn(event, function(err, message) {
     t.deepEqual(message, {
-      body: eventName + ' called on arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail',
-      subject: eventName + ' called on arn:aws:cloudtrail:us-east-1:12345678901:trail:bob-cloudtrail'
+      body: eventName + ' - CloudTrail',
+      subject: eventName + ' - CloudTrail'
     }, 'Matches ' + eventName + ' CloudTrail event');
   });
 


### PR DESCRIPTION
- Removes ARN of CloudTrail from SNS message
- Changes CloudWatch event from wildcard to an array of specified events, to prevent false positives

/cc @ianshward 
