### PR TITLE
Move build and rules commands to ./bin

### DIFF
--- a/bin/crowsnest-build.js
+++ b/bin/crowsnest-build.js
@@ -1,6 +1,8 @@
-var lambdaCfn = require('./lib/lambda-cfn');
+#!/usr/bin/env node
 
-var rules = require('./index').rules;
+var lambdaCfn = require('../lib/lambda-cfn');
+
+var rules = require('../index').rules;
 var built = [];
 
 rules.forEach(function(rule) {

--- a/bin/crowsnest-rules.js
+++ b/bin/crowsnest-rules.js
@@ -1,6 +1,8 @@
+#!/usr/bin/env node
+
 var AWS = require('aws-sdk');
 var queue = require('queue-async');
-var rules = require('./index').rules;
+var rules = require('../index').rules;
 
 if (!process.argv[2])
   throw new Error('Must provide name of CloudFormation stack as first argument');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "pretest": "jshint index.js && jscs index.js",
     "test": "NODE_ENV=test tape test/*.test.js test/**/*.test.js"
   },
+  "bin": {
+    "crowsnest-build": "./bin/crowsnest-build.js",
+    "crowsnest-rules": "./bin/crowsnest-rules.js"
+  },
   "dependencies": {
     "streambot": "3.4.0",
     "queue-async": "1.0.7"


### PR DESCRIPTION
This moves build and rules commands to ./bin and makes them available as `crowsnest-build` and `crowsnest-rules` when you npm link.
