### PR TITLE
[first cut] update rollback failed lambda

### DIFF
--- a/rules/updateRollbackFailed.js
+++ b/rules/updateRollbackFailed.js
@@ -1,0 +1,82 @@
+module.exports = {};
+module.exports.describeStacks = describeStacks;
+var AWS = require('aws-sdk');
+var queue = require('d3-queue').queue;
+var message = require('lambda-cfn').message;
+var splitOnComma = require('lambda-cfn').splitOnComma;
+var getEnv = require('lambda-cfn').getEnv;
+var util = require('util');
+var allStacks = [];
+
+module.exports.config = {
+  name: 'updateRollbackFailed',
+  sourcePath: 'rules/updateRollbackFailed.js',
+  parameters: {
+    includeResources: {
+      Type: 'String',
+      Description: 'Comma separated list of stacks which don\'t have production in their stackname'
+    }
+  },
+  statements: [
+    {
+      Effect: 'Allow',
+      Action: [
+        'cloudformation:*'
+      ],
+      Resource: '*'
+    }
+  ],
+  scheduledRule: 'rate(5 minutes)'
+};
+
+module.exports.fn = function(event, callback) {
+  var productionStacks = [];
+  var included = splitOnComma(getEnv('includeResources'));
+  var q = queue(1);
+  q.defer(describeStacks, {});
+  q.awaitAll(function (err, data) {
+    if (err) return callback(err);
+    else {
+        data[0].forEach(function(i) {
+          if(i.name.indexOf('production') > -1  && i.status.indexOf('UPDATE_COMPLETE') > -1) {
+            var notif = {
+              subject: 'Production stack in UPDATE_ROLLBACK_FAILED',
+              summary: 'Production stack'+ i +'in UPDATE_ROLLBACK_FAILED',
+              event: i
+            };
+            message(notif, function(err, result) {
+              callback(err, result);
+            });
+          }else {
+            return callback(null, 'No service in UPDATE_ROLLBACK_FAILED');
+          }
+        });
+      }
+    });
+};
+
+function describeStacks(params, callback) {
+  var q1 = queue(1);
+  var cloudformation = new AWS.CloudFormation({region: 'us-east-1'});
+  cloudformation.describeStacks(params, function(err, data) {
+    if (err) return callback(err); 
+    if (data.NextToken) {
+      params.NextToken = data.NextToken;
+      data.Stacks.forEach(function(i){
+        allStacks.push({name:i.StackName, status:i.StackStatus});
+      }); 
+      q1.defer(describeStacks, params, callback);
+    } else {
+      data.Stacks.forEach(function(i){
+        allStacks.push({name:i.StackName, status:i.StackStatus});
+        return callback(null, allStacks);
+      });
+    }
+    q1.awaitAll(function (err, data) {
+      if (err) return callback(err);
+      else {
+        return callback(null, allStacks);
+      }
+    });
+  });
+}

--- a/test/rules/fixtures/describeStack.json
+++ b/test/rules/fixtures/describeStack.json
@@ -1,0 +1,18 @@
+{
+    "ResponseMetadata": {
+        "RequestId ": "d0000 - abcd - 12e6 - b466 - 975195 fghh"
+    },
+    "Stacks": [{
+        "StackId": "arn:aws:cloudformation:something-production",
+        "StackName": "something-production",
+        "Description": "something",
+        "Parameters": [{}],
+        "CreationTime": "Wed Nov 09 2016 14: 18: 09 GMT - 0500(EST)",
+        "StackStatus": "UPDATE_ROLLBACK_FAILED",
+        "DisableRollback": true,
+        "NotificationARNs": [],
+        "Capabilities": [{}],
+        "Outputs": [{}],
+        "Tags": []
+    }]
+}

--- a/test/rules/updateRollbackFailed.test.js
+++ b/test/rules/updateRollbackFailed.test.js
@@ -1,0 +1,54 @@
+var rule = require('../../rules/updateRollbackFailed');
+var stacks = require('./fixtures/describeStack.json');
+var test = require('tape');
+var fn = rule.fn;
+var name = rule.config.name;
+var event = {};
+var AWS = require('aws-sdk');
+var originalCloudFormation = AWS.CloudFormation;
+var originalSNS = AWS.SNS;
+
+test('mocking cloudformation', function(t) {
+AWS.CloudFormation = MockCloudFormation;
+    function MockCloudFormation() {}
+    MockCloudFormation.prototype.describeStacks = function (params, callback) {
+        callback(null, stacks);
+    };
+	t.end();
+});
+
+test('Mock SNS publish', function (assert) {
+    AWS.SNS = MockSNS;
+    function MockSNS() {}
+
+    MockSNS.prototype.publish = function (param, callback) {
+        param = {
+            Subject: 'Production stack in UPDATE_ROLLBACK_FAILED',
+            Message: 'Production stack something-production in UPDATE_ROLLBACK_FAILED',
+            event: 'something'
+        };
+        assert.deepEqual(typeof param, 'object', 'Parameter is an object.');
+        assert.deepEqual(typeof param.Message, 'string', 'Parameter\'s message is a String.');
+        assert.deepEqual(param.event, 'something', 'event matches');
+        return callback(null, 'No service in UPDATE_ROLLBACK_FAILED');
+    };
+    assert.end();
+});
+
+test('update Rollback Failed check for production stacks', function(t) {
+  fn(event, function(err, message) {
+  	t.deepEquals(message, 'No service in UPDATE_ROLLBACK_FAILED', 'ok no stack in UPDATE_ROLLBACK_FAILED');
+  	t.ifError(err);
+  	t.end();
+  });
+});
+
+test('[CloudFormation] restore', function(t) {
+    AWS.CloudFormation = originalCloudFormation;
+    t.end();
+});
+
+test('[SNS]', function (assert) {
+    AWS.SNS = originalSNS;
+    assert.end();
+});


### PR DESCRIPTION
There are times when stacks are caught in`UPDATE_ROLLBACK_FAILED` and it's good to be alerted when a stack is in such a state. Since there are no cloudwatch events that currently track this, the easiest way was to create a lambda function that would do that looks at which productions are currently in the `UPDATE_ROLLBACK_FAILED` state and alert in case that is the case. 
I'm currently testing for whether the stack is in `UPDATE_COMPLETE` to see if it sends a notification will change this back to `UPDATE_ROLLBACK_FAILED` when I confirm this works. 

cc @ianshward, @emilymcafee - does this look okay ?

Next actions: 
- [ ] Create staging stack 
- [ ] test 😅 
