### PR TITLE
Rule for when a bucket ACL changes

### DIFF
--- a/rules/bucketACL.js
+++ b/rules/bucketACL.js
@@ -1,0 +1,42 @@
+var message = require('lambda-cfn').message;
+
+module.exports.config = {
+  name: 'bucketACL',
+  runtime: 'nodejs4.3',
+  sourcePath: 'rules/bucketACL.js',
+  eventRule: {
+    eventPattern: {
+      'detail-type': [
+        'AWS S3 bucket ACL change'
+      ],
+      detail: {
+        eventSource: [
+          's3.amazonaws.com'
+        ],
+        eventName: [
+          'PutBucketAcl'
+        ]
+      }
+    }
+  }
+};
+
+module.exports.fn = function(event, context, callback) {
+  if (event.detail.errorCode)
+    return callback(null, event.detail.errorMessage);
+  var bucketName = event.detail.requestParameters.bucketName;
+
+  if (event.detail.eventName === 'PutBucketAcl') {
+    var notif = {
+      subject: 'Bucket ACL was changed.',
+      summary: 'Patrol detected that ' + bucketName + ' ACL has changed.',
+      event: event
+    };
+    console.log(notif);
+    message(notif, function(err, result) {
+      callback(err, result);
+    });
+  } else {
+    callback(null, 'Bucket ACL was not changed.')
+  }
+};

--- a/test/rules/bucketACL.test.js
+++ b/test/rules/bucketACL.test.js
@@ -1,0 +1,20 @@
+var test = require('tape');
+var rule = require('../../rules/bucketACL');
+var fn = rule.fn;
+
+test('Detects bucket ACL changed correctly', function(t) {
+  rule.fn(bucketAclEvent, {}, function(err, message) {
+    t.equal(message.subject, 'Bucket ACL was changed.', 'Detect bucket ACL was changed');
+    t.end();
+  });
+});
+
+var bucketAclEvent = {
+  "detail": {
+    "eventSource": "s3.amazonaws.com",
+    "eventName": "PutBucketAcl",
+    "requestParameters": {
+      "bucketName": "mapbox"
+    }
+  }
+}


### PR DESCRIPTION
As part of me [learning patrol](https://github.com/mapbox/patrol-service/issues/132), I created a rule for when a bucket ACL changes.

This just looks at the `eventName` for `PutBucketACL` and will fire off an alarm for any event with that name. I'm assuming we'll take a look at these alerts individually as they shouldn't happen fairly often (only two have happened so far this month).