### PR TITLE
Detect when encryption removed from an S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ The following functions are included with patrol-rules-aws.  Each rule is config
 - **Parameters**
   - disallowedResourceARNs - Comma separated list of AWS ARNs.  An alarm will be triggered if an IAM policy grants any kind of access to these resources.
 
+#### removeS3ManagedEncryption
+
+- **Description** - Checks for removing encryption from an S3 bucket.
+- **Trigger** - `DeleteBucketEncryption` AWS API call
+
 #### rootLogin
 - **Description** - Checks if the root AWS user logged in to the console
 - **Trigger** - AWS Console Sign-in

--- a/removeS3ManagedEncryption/function.js
+++ b/removeS3ManagedEncryption/function.js
@@ -1,0 +1,16 @@
+const lambdaCfn = require('@mapbox/lambda-cfn');
+
+module.exports.fn = function(event, context, callback) {
+  if (event.detail.errorCode) return callback(null, event.detail.errorMessage);
+
+  let message = {
+    subject: `Bucket encryption removed from ${event.detail.requestParameters.bucketName}`,
+    summary: `AWS managed S3 encryption removed from ${event.detail.requestParameters.bucketName}`,
+    event: event
+  };
+
+  lambdaCfn.message(message, (err, result) => {
+    callback(err, result);
+  });
+
+};

--- a/removeS3ManagedEncryption/function.js
+++ b/removeS3ManagedEncryption/function.js
@@ -3,7 +3,7 @@ const lambdaCfn = require('@mapbox/lambda-cfn');
 module.exports.fn = function(event, context, callback) {
   if (event.detail.errorCode) return callback(null, event.detail.errorMessage);
 
-  let message = {
+  const message = {
     subject: `Bucket encryption removed from ${event.detail.requestParameters.bucketName}`,
     summary: `AWS managed S3 encryption removed from ${event.detail.requestParameters.bucketName}`,
     event: event

--- a/removeS3ManagedEncryption/function.template.js
+++ b/removeS3ManagedEncryption/function.template.js
@@ -1,4 +1,4 @@
-var lambdaCfn = require('@mapbox/lambda-cfn');
+const lambdaCfn = require('@mapbox/lambda-cfn');
 
 module.exports = lambdaCfn.build({
   name: 'removeS3ManagedEncryption',

--- a/removeS3ManagedEncryption/function.template.js
+++ b/removeS3ManagedEncryption/function.template.js
@@ -1,0 +1,22 @@
+var lambdaCfn = require('@mapbox/lambda-cfn');
+
+module.exports = lambdaCfn.build({
+  name: 'removeS3ManagedEncryption',
+  eventSources: {
+    cloudwatchEvent: {
+      eventPattern: {
+        'detail-type': [
+          'AWS API Call via CloudTrail'
+        ],
+        detail: {
+          eventSource: [
+            's3.amazonaws.com'
+          ],
+          eventName: [
+            'DeleteBucketEncryption'
+          ]
+        }
+      }
+    }
+  }
+});

--- a/test/removeS3ManagedEncryption.test.js
+++ b/test/removeS3ManagedEncryption.test.js
@@ -1,0 +1,26 @@
+const test = require('tape');
+
+const rule = require('../removeS3ManagedEncryption/function.js');
+const fn = rule.fn;
+
+test('Alerts if S3 managed encryption removed from bucket', (t) => {
+
+  let event = {
+    'detail': {
+      'eventSource': 's3.amazonaws.com',
+      'eventName': 'DeleteBucketEncryption',
+      'requestParameters': {
+        'encryption': [ '' ],
+        'bucketName': 'i-has-a-bucket'
+      }
+    }
+  };
+
+  fn(event, {}, (err, message) => {
+    console.log(err);
+    t.error(err, 'does not error');
+    t.equal(message.subject, 'Bucket encryption removed from i-has-a-bucket', 'Should alarm when encryption removed');
+    t.end();
+  });
+
+});

--- a/test/removeS3ManagedEncryption.test.js
+++ b/test/removeS3ManagedEncryption.test.js
@@ -17,7 +17,6 @@ test('Alerts if S3 managed encryption removed from bucket', (t) => {
   };
 
   fn(event, {}, (err, message) => {
-    console.log(err);
     t.error(err, 'does not error');
     t.equal(message.subject, 'Bucket encryption removed from i-has-a-bucket', 'Should alarm when encryption removed');
     t.end();

--- a/test/removeS3ManagedEncryption.test.js
+++ b/test/removeS3ManagedEncryption.test.js
@@ -5,7 +5,7 @@ const fn = rule.fn;
 
 test('Alerts if S3 managed encryption removed from bucket', (t) => {
 
-  let event = {
+  const event = {
     'detail': {
       'eventSource': 's3.amazonaws.com',
       'eventName': 'DeleteBucketEncryption',


### PR DESCRIPTION
This PR adds a Patrol rule to detect if encryption is removed from an S3 bucket via the `DeleteBucketEncryption` CloudTrail event.

One potential unknown - this rule was tested with disabling and enabling AWS SSE-S3 encryption. I'm unsure what the CloudTrail event looks like for disabling SSE-KMS encryption. I can find this out with additional testing. 

Either way, I would want an alarm for the removal of either type of encryption. Having the entire `event` in the SNS message might help in determining which type of encryption was disabled. The CloudTrail event for `DeleteBucketEncryption` is sparse and lacking details.

@matiskay @ianshward - can I have a quick code review and gut check from either of you?