### PR TITLE
Detect if S3 server access logging disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ The following functions are included with patrol-rules-aws.  Each rule is config
 - **Parameters**
   - disallowedResourceARNs - Comma separated list of AWS ARNs.  An alarm will be triggered if an IAM policy grants any kind of access to these resources.
 
+#### removeS3AccessLogging
+
+- **Description** - Checks for removing server access logging from an S3 bucket
+- **Trigger** - `PutBucketLogging` AWS API call
+
 #### rootLogin
 - **Description** - Checks if the root AWS user logged in to the console
 - **Trigger** - AWS Console Sign-in

--- a/removeS3AccessLogging/function.js
+++ b/removeS3AccessLogging/function.js
@@ -1,0 +1,22 @@
+const lambdaCfn = require('@mapbox/lambda-cfn');
+
+module.exports.fn = function(event, context, callback) {
+  if (event.detail.errorCode) return callback(null, event.detail.errorMessage);
+
+  const requestParameters = event.detail.requestParameters;
+  const accessLoggingStatus = requestParameters.BucketLoggingStatus.LoggingEnabled;
+
+  if (accessLoggingStatus === undefined) {
+    const message = {
+      subject: `S3 server access logging removed from ${requestParameters.bucketName}`,
+      summary: `S3 server access logging removed from ${requestParameters.bucketName}`,
+      event: event
+    };
+    lambdaCfn.message(message, (err, result) => {
+      callback(err, result);
+    });
+  } else {
+    callback(null, 'S3 server access logging not disabled.');
+  }
+
+};

--- a/removeS3AccessLogging/function.template.js
+++ b/removeS3AccessLogging/function.template.js
@@ -1,0 +1,22 @@
+var lambdaCfn = require('@mapbox/lambda-cfn');
+
+module.exports = lambdaCfn.build({
+  name: 'removeS3AccessLogging',
+  eventSources: {
+    cloudwatchEvent: {
+      eventPattern: {
+        'detail-type': [
+          'AWS API Call via CloudTrail'
+        ],
+        detail: {
+          eventSource: [
+            's3.amazonaws.com'
+          ],
+          eventName: [
+            'PutBucketLogging'
+          ]
+        }
+      }
+    }
+  }
+});

--- a/test/removeS3AccessLogging.test.js
+++ b/test/removeS3AccessLogging.test.js
@@ -1,0 +1,58 @@
+const test = require('tape');
+
+const rule = require('../removeS3AccessLogging/function');
+const fn = rule.fn;
+
+test('Detects if access logging is disabled on bucket', (t) => {
+  const event = {
+    'detail': {
+      'eventSource': 's3.amazonaws.com',
+      'eventName': 'PutBucketLogging',
+      'requestParameters': {
+        'BucketLoggingStatus': {
+          'xmlns': 'http://doc.s3.amazonaws.com/2006-03-01/'
+        },
+        'bucketName': 'lolrus',
+        'logging': [
+          ''
+        ]
+      }
+    }
+  };
+
+  fn(event, {}, (err, message) => {
+    t.error(err, 'does not error');
+    t.equal(message.subject, 'S3 server access logging removed from lolrus', 'Should detect that access logging removed');
+    t.end();
+  });
+
+});
+
+test('Do not trigger notification when access logging is enabled.', (t) => {
+  const event = {
+    'detail': {
+      'eventSource': 's3.amazonaws.com',
+      'eventName': 'PutBucketLogging',
+      'requestParameters': {
+        'BucketLoggingStatus': {
+          'xmlns': 'http://doc.s3.amazonaws.com/2006-03-01/',
+          'LoggingEnabled': {
+            'TargetPrefix': 'lolrus/',
+            'TargetBucket': 'access-logging-bucket'
+          }
+        },
+        'bucketName': 'lolrus',
+        'logging': [
+          ''
+        ]
+      }
+    }
+  };
+
+  fn(event, {}, (err, message) => {
+    t.error(err, 'Does not error');
+    t.equal(message, 'S3 server access logging not disabled.', 'It should not send a notification');
+    t.end();
+  });
+
+});


### PR DESCRIPTION
This rule detects and notifies if [S3 server access logging](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html) is disabled on a bucket.

Both enabling and disabling S3 access logging use the `PutBucketLogging` CloudTrail event name. Enabling access logging adds a `LoggingEnabled` property to `BucketLoggingStatus` in `requestParameters`. This is missing in the CloudTrail event for disabling access logging, which is why I check for `undefined` in the rule for disabling access logging.

@matiskay @ianshward - another quick gut check and code review from either of you?