### PR TITLE
fix lambda erorring on buckets that have no grants whatsoever

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/mapbox/patrol-rules-aws/issues"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "dependencies": {
     "d3-queue": "^3.0.0",
     "@mapbox/lambda-cfn": "^2.0.0"

--- a/publicBucketACL/function.js
+++ b/publicBucketACL/function.js
@@ -16,6 +16,9 @@ module.exports.fn = function(event, context, callback) {
 function publicPermissions(event) {
   let permissions = [];
   let grants = event.detail.requestParameters.AccessControlPolicy.AccessControlList.Grant;
+  if (typeof grants === 'undefined') { // Catches edge case in which a bucket is created that nobody has permissions to
+    return permissions;
+  }
 
   for (let i = 0; i < grants.length; i++) {
     if (grants[i].Grantee.URI === 'http://acs.amazonaws.com/groups/global/AllUsers') {

--- a/test/publicBucketACL.test.js
+++ b/test/publicBucketACL.test.js
@@ -112,3 +112,25 @@ test('Trigger notification on multiple public access permissions.', (t) => {
     t.end();
   });
 });
+
+test('Doesn\'t error if Grant field doesn\'t exist.', (t) => {
+  var event = {
+    'detail': {
+      'eventSource': 's3.amazonaws.com',
+      'eventName': 'PutBucketAcl',
+      'requestParameters': {
+        'bucketName': 'mapbox',
+        'AccessControlPolicy': {
+          'AccessControlList': {
+          }
+        }
+      }
+    }
+  };
+
+  fn(event, {}, (err, message) => {
+    t.error(err, 'does not error');
+    t.equal(message, 'Bucket Public Access ACL was not changed.', 'It should not send any message');
+    t.end();
+  });
+});


### PR DESCRIPTION
Fixed edge case in which lambda errors out when a user creates a bucket that nobody, not even themselves, has permissions to.

```
TypeError: Cannot read property 'length' of undefined
at publicPermissions (/var/task/publicBucketACL/function.js:20:29)
at module.exports.fn (/var/task/publicBucketACL/function.js:7:23)
```