### PR TITLE
Alarm exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following functions are included with patrol-rules-aws.  Each rule is config
 - **Parameters**
   - restrictedServices - Comma separated list of services on which to disallow all actions
   - allowedActions - on the restrictedServices, only allow these actions to be granted
+  - ignoredRolePolicy - Comma separated list of colon delimited role:policy combinations that should be ignored if matched. The "role:policy" values are case-insensitively matched against the policy event.
 
 #### assumeRole
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The following functions are included with patrol-rules-aws.  Each rule is config
 - **Trigger** - AWS API call
 - **Parameters**
   - disallowedResourceARNs - Comma separated list of AWS ARNs.  An alarm will be triggered if an IAM policy grants any kind of access to these resources.
+  - ignoredRolePolicy - Comma separated list of colon delimited role:policy combinations that should be ignored if matched. The "role:policy" values are case-insensitively matched against the policy event.
 
 #### removeS3AccessLogging
 

--- a/allowedIAMActions/function.js
+++ b/allowedIAMActions/function.js
@@ -3,9 +3,29 @@ const lambdaCfn = require('@mapbox/lambda-cfn');
 module.exports.fn = (event, context, callback) => {
   if (event.detail.errorCode) return callback(null, event.detail.errorMessage);
 
-  let allowedActions = lambdaCfn.splitOnComma(process.env.allowedActions);
-  let document = JSON.parse(event.detail.requestParameters.policyDocument);
-  let restrictedServices = lambdaCfn.splitOnComma(process.env.restrictedServices);
+  const allowedActions = lambdaCfn.splitOnComma(process.env.allowedActions);
+  const document = JSON.parse(event.detail.requestParameters.policyDocument);
+  const restrictedServices = lambdaCfn.splitOnComma(process.env.restrictedServices);
+  const ignoredRolePolicy = lambdaCfn.splitOnComma(process.env.ignoredRolePolicy);
+
+  const role = event.detail.userIdentity.sessionContext.sessionIssuer.userName ? event.detail.userIdentity.sessionContext.sessionIssuer.userName : 'unknown';
+  const policyArn = event.detail.requestParameters.policyArn ? event.detail.requestParameters.policyArn : 'unknown';
+
+  if (ignoredRolePolicy.length > 0) {
+    let skipMsg;
+    let matched;
+    ignoredRolePolicy.forEach((pair) => {
+      const ignoredRole = new RegExp(pair.split(':')[0], 'i');
+      const ignoredPolicy = new RegExp(pair.split(':')[1], 'i');
+
+      if (ignoredRole.test(role) && ignoredPolicy.test(policyArn)) {
+        skipMsg = `Matched role '${role}' and policyArn '${policyArn}' to ignoredRolePolicy value '${pair}', skipping`;
+        console.log(skipMsg);
+        matched = true;
+      }
+    });
+    if (matched) return callback(null, skipMsg);
+  };
 
   // build list of actions used.
   let actions = [];

--- a/allowedIAMActions/function.template.js
+++ b/allowedIAMActions/function.template.js
@@ -10,6 +10,10 @@ module.exports = lambdaCfn.build({
     allowedActions: {
       Type: 'String',
       Description: 'Comma separated list of actions to allow among restricted services'
+    },
+    ignoredRolePolicy: {
+      Type: 'String',
+      Description: 'Comma separated list of colon delimited role:policy pairs to ignore'
     }
   },
   eventSources: {

--- a/disallowedResources/function.template.js
+++ b/disallowedResources/function.template.js
@@ -6,6 +6,10 @@ module.exports = lambdaCfn.build({
     disallowedResourceArns: {
       Type: 'String',
       Description: 'Comma separated list of ARNs to disallow. Any policy document that grants access to these ARNs will trigger a notification.'
+    },
+    ignoredRolePolicy: {
+      Type: 'String',
+      Description: 'Comma separated list of colon delimited role:policy pairs to ignore'
     }
   },
   eventSources: {

--- a/test/allowedIAMActions.test.js
+++ b/test/allowedIAMActions.test.js
@@ -176,5 +176,6 @@ test('allowedIAMActions rule', (t) => {
     t.equal(message, 'Matched role \'bob\' and policyArn \'arn:aws:iam::12345678901:role/Administrator-123456\' to ignoredRolePolicy value \'BOB:Adminis\', skipping', 'Multiple Role:Policy, with one match, passes correctly');
   });
 
+  delete process.env.ignoredRolePolicy;
   t.end();
 });

--- a/test/allowedIAMActions.test.js
+++ b/test/allowedIAMActions.test.js
@@ -159,8 +159,7 @@ test('allowedIAMActions rule', (t) => {
 
   fn(event, {}, (err, message) => {
     t.error(err, 'does not error');
-    t.equal(message.subject, 'Disallowed actions used in policy',
-            'Role:Policy, correctly, does not match');
+    t.equal(message.subject, 'Disallowed actions used in policy', 'Role:Policy, correctly, does not match');
   });
 
   process.env.ignoredRolePolicy = 'BOB:Adminis';

--- a/test/allowedIAMActions.test.js
+++ b/test/allowedIAMActions.test.js
@@ -8,11 +8,14 @@ test('allowedIAMActions rule', (t) => {
   var event = {
     'detail': {
       'userIdentity': {
-        'userName': 'bob'
+        'sessionContext': {
+          'sessionIssuer': {
+            'userName': 'bob'
+          }
+        }
       },
       'requestParameters': {
-        'roleArn': 'arn:aws:iam::12345678901:role/Administrator-123456',
-        'roleSessionName': 'bob'
+        'policyArn': 'arn:aws:iam::12345678901:role/Administrator-123456'
       }
     }
   };
@@ -55,9 +58,9 @@ test('allowedIAMActions rule', (t) => {
   fn(event, {}, (err, message) => {
     t.error(err, 'does not error');
     t.equal(message.subject, 'Disallowed actions used in policy',
-      'Alarms on multiple disallowed matches');
+      'Alarms on multiple disallowed subject matches');
     t.equal(message.summary, 'Disallowed actions cloudtrail:* iam:* iam:PutUserPolicy used in policy',
-      'Alarms on multiple disallowed matches');
+      'Alarms on multiple disallowed summary matches');
   });
 
   var docAllowedRestricted = {
@@ -82,9 +85,9 @@ test('allowedIAMActions rule', (t) => {
   fn(event, {}, (err, message) => {
     t.error(err, 'does not error');
     t.equal(message.subject, 'Disallowed actions used in policy',
-      'Alarms on multiple disallowed matches');
+      'Alarms on multiple disallowed subject matches');
     t.equal(message.summary, 'Disallowed actions iam:PutUserPolicy used in policy',
-      'Alarms on multiple disallowed matches');
+      'Alarms on multiple disallowed summary matches');
   });
 
   var docAllowed = {
@@ -130,11 +133,14 @@ test('allowedIAMActions rule', (t) => {
   event = {
     'detail': {
       'userIdentity': {
-        'userName': 'bob'
+        'sessionContext': {
+          'sessionIssuer': {
+            'userName': 'bob'
+          }
+        }
       },
       'requestParameters': {
-        'roleArn': 'arn:aws:iam::12345678901:role/Administrator-123456',
-        'roleSessionName': 'bob'
+        'policyArn': 'arn:aws:iam::12345678901:role/Administrator-123456'
       }
     }
   };
@@ -144,9 +150,31 @@ test('allowedIAMActions rule', (t) => {
   fn(event, {}, (err, message) => {
     t.error(err, 'does not error');
     t.equal(message.subject, 'Disallowed actions used in policy',
-      'Alarms on single non-array disallowed match');
+      'Alarms on single non-array disallowed subject match');
     t.equal(message.summary, 'Disallowed actions iam:PutUserPolicy used in policy',
-      'Alarms on single non-array disallowed match');
+      'Alarms on single non-array disallowed summary match');
+  });
+
+  process.env.ignoredRolePolicy = 'ROLE:Policy';
+
+  fn(event, {}, (err, message) => {
+    t.error(err, 'does not error');
+    t.equal(message.subject, 'Disallowed actions used in policy',
+            'Role:Policy, correctly, does not match');
+  });
+
+  process.env.ignoredRolePolicy = 'BOB:Adminis';
+
+  fn(event, {}, (err, message) => {
+    t.error(err, 'does not error');
+    t.equal(message, 'Matched role \'bob\' and policyArn \'arn:aws:iam::12345678901:role/Administrator-123456\' to ignoredRolePolicy value \'BOB:Adminis\', skipping', 'Role:Policy matches correctly');
+  });
+
+  process.env.ignoredRolePolicy = 'jaNe:Super,BOB:Adminis';
+
+  fn(event, {}, (err, message) => {
+    t.error(err, 'does not error');
+    t.equal(message, 'Matched role \'bob\' and policyArn \'arn:aws:iam::12345678901:role/Administrator-123456\' to ignoredRolePolicy value \'BOB:Adminis\', skipping', 'Multiple Role:Policy, with one match, passes correctly');
   });
 
   t.end();


### PR DESCRIPTION
Updates the "allowedIAMActions" and "disallowedResources" patrol rules and added a new parameter "ignoredRolePolicy". This is a comma separated colon delimited list of role:policy pairs that are case-insensitively matched against the policy event. Both must match for the tests to be skipped. 